### PR TITLE
Add missing check for zero path size

### DIFF
--- a/ss-server/index.go
+++ b/ss-server/index.go
@@ -110,6 +110,10 @@ func index(dir string, recursive bool, excludeFunc ExcludeFunc, shouldNotReplace
 }
 
 func addFile(servPath, clientPath string, shouldNotReplace bool) error {
+	if _, err := os.Stat(servPath); err != nil {
+		return err
+	}
+
 	filesMap[clientPath] = IndexedFile{servPath, clientPath, shouldNotReplace}
 	return nil
 }

--- a/ss-server/server.go
+++ b/ss-server/server.go
@@ -87,6 +87,10 @@ func (s *Service) serve(conn *tls.Conn) {
 			return
 		}
 
+		if size == 0 {
+			break
+		}
+
 		// Expect file path
 		data = make([]byte, size)
 		err = binary.Read(conn, binary.LittleEndian, data)


### PR DESCRIPTION
Client sends zero-length file path as terminator. Server code doesn't
checks for it and just loops forever.